### PR TITLE
change devtool 'inline-source-map' to 'source-map'

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@ const extensions = ['.tsx', '.ts', '.js', 'json']
 
 module.exports = {
   entry: './src/index.ts',
-  devtool: 'inline-source-map',
+  devtool: 'source-map',
   module: {
     rules: [
       {


### PR DESCRIPTION
This allows to divide by 4 the size of the bundle.js produced with "yarn browser".